### PR TITLE
Refactor createTeam to a Cloud Function

### DIFF
--- a/index.html
+++ b/index.html
@@ -728,6 +728,10 @@ body.dark .stat-card-info p {
                 <label for="team-name-input" class="block text-sm font-medium mb-1">Team Name</label>
                 <input type="text" id="team-name-input" class="w-full px-4 py-2.5 text-base rounded-lg shadow-inner focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all" placeholder="Enter team name">
             </div>
+            <div>
+                <label for="team-owner-display-name-input" class="block text-sm font-medium mb-1">Your Display Name</label>
+                <input type="text" id="team-owner-display-name-input" class="w-full px-4 py-2.5 text-base rounded-lg shadow-inner focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all" placeholder="How others will see you">
+            </div>
         </div>
         <div class="flex justify-end mt-6 space-x-3">
             <button id="cancel-create-team-btn" class="px-5 py-2 btn-secondary rounded-lg">Cancel</button>


### PR DESCRIPTION
This commit refactors the `createTeam` functionality from a client-side Firestore batch write to a server-side Firebase Cloud Function.

The new `createTeam` cloud function:
- Ensures that only authenticated users can create teams.
- Validates the input data (teamName, displayName).
- Creates the team and updates the user's document within a transaction to ensure atomicity.
- Generates a unique room code for the new team.

The client-side `createTeam` function in `app.js` is updated to call this new cloud function. A new input field for the team owner's display name has been added to the "Create Team" modal in `index.html`.