### PR TITLE
fix: Add accessible names to buttons

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,6 +42,21 @@ const TEAM_ROLES = {
     MEMBER: 'member'
 };
 
+const COLOR_MAP = {
+    '#ef4444': 'Red',
+    '#f97316': 'Orange',
+    '#eab308': 'Yellow',
+    '#84cc16': 'Lime',
+    '#22c55e': 'Green',
+    '#14b8a6': 'Teal',
+    '#06b6d4': 'Cyan',
+    '#3b82f6': 'Blue',
+    '#8b5cf6': 'Violet',
+    '#d946ef': 'Fuchsia',
+    '#ec4899': 'Pink',
+    '#78716c': 'Gray'
+};
+
 // --- Global App State ---
 let state = {
     currentMonth: new Date(),
@@ -1458,9 +1473,9 @@ function closeLeaveTypeModal() {
 }
 
 function setupColorPicker() {
-    const colors = ['#ef4444', '#f97316', '#eab308', '#84cc16', '#22c55e', '#14b8a6', '#06b6d4', '#3b82f6', '#8b5cf6', '#d946ef', '#ec4899', '#78716c'];
+    const colors = Object.keys(COLOR_MAP);
     DOM.leaveColorPicker.innerHTML = colors.map(color => `
-        <button type="button" data-color="${color}" style="background-color: ${color};" class="w-10 h-10 rounded-full border-2 border-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"></button>
+        <button type="button" data-color="${color}" aria-label="Select color: ${COLOR_MAP[color]}" style="background-color: ${color};" class="w-10 h-10 rounded-full border-2 border-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"></button>
     `).join('');
 }
 

--- a/index.html
+++ b/index.html
@@ -611,7 +611,7 @@ body.dark .stat-card-info p {
     <div class="modal-container rounded-xl shadow-2xl p-6 w-full max-w-2xl max-h-[90vh] grid grid-rows-[auto_auto_1fr] mt-8">
         <div class="flex justify-between items-center mb-4">
             <h2 class="text-2xl font-bold truncate">Leave Overview</h2>
-            <button id="close-leave-overview-btn" class="icon-btn">
+            <button id="close-leave-overview-btn" class="icon-btn" aria-label="Close leave overview">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                 </svg>
@@ -693,11 +693,11 @@ body.dark .stat-card-info p {
 <div id="month-picker-modal" class="smooth-modal fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 modal-backdrop">
     <div class="modal-container rounded-xl shadow-2xl p-6 w-full max-w-md">
         <div class="flex justify-between items-center mb-6">
-            <button id="prev-year-btn" class="p-2 btn-secondary rounded-full">
+            <button id="prev-year-btn" class="p-2 btn-secondary rounded-full" aria-label="Previous Year">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7"></path></svg>
             </button>
             <h3 id="picker-year-display" class="text-2xl font-semibold">2023</h3>
-            <button id="next-year-btn" class="p-2 btn-secondary rounded-full">
+            <button id="next-year-btn" class="p-2 btn-secondary rounded-full" aria-label="Next Year">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M6 5l7 7-7 7"></path></svg>
             </button>
         </div>
@@ -762,7 +762,7 @@ body.dark .stat-card-info p {
     <div class="modal-container rounded-xl shadow-2xl p-6 w-full max-w-6xl max-h-[90vh] grid grid-rows-[auto_1fr] mt-8">
         <div class="flex justify-between items-center mb-6">
             <h2 class="text-2xl font-bold truncate">Team Dashboard</h2>
-            <button id="close-team-dashboard-btn" class="icon-btn">
+            <button id="close-team-dashboard-btn" class="icon-btn" aria-label="Close team dashboard">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                 </svg>


### PR DESCRIPTION
This commit addresses several accessibility issues where buttons were missing accessible names, making them unusable for screen reader users.

The following changes were made:
- Added `aria-label` attributes to the close buttons in the "Leave Overview" and "Team Dashboard" modals.
- Added `aria-label` attributes to the "Previous Year" and "Next Year" buttons in the month picker.
- Refactored the `setupColorPicker` function in `app.js` to dynamically generate `aria-label` attributes for the color picker buttons, providing a human-readable color name (e.g., "Select color: Red").