### PR TITLE
fix(ui): Prevent modal flicker on team dashboard load

### DIFF
--- a/app.js
+++ b/app.js
@@ -2486,8 +2486,8 @@ async function kickMember() {
 }
 
 function openTeamDashboard() {
-    DOM.teamDashboardModal.classList.add('visible');
     renderTeamDashboard();
+    DOM.teamDashboardModal.classList.add('visible');
 }
 
 function closeTeamDashboard() {


### PR DESCRIPTION
The team dashboard modal was made visible before its content was rendered, causing a brief flicker where an empty modal container would appear on the screen.

This change modifies the `openTeamDashboard` function to call `renderTeamDashboard()` *before* adding the 'visible' class to the modal. This ensures the modal's content is fully prepared before it is displayed, providing a smoother user experience and eliminating the visual artifact.