### PR TITLE
Fix: Update button style and fix daily note saving

### DIFF
--- a/app.js
+++ b/app.js
@@ -2756,10 +2756,10 @@ function setupEventListeners() {
         setButtonLoadingState(button, false);
     });
 
-    // Use 'change' event for more reliable saving when the user clicks away
-    DOM.dailyNoteInput.addEventListener('change', (e) => {
+    // Use debounced 'input' for a better UX
+    DOM.dailyNoteInput.addEventListener('input', debounce((e) => {
         saveData({ type: ACTION_TYPES.SAVE_NOTE, payload: e.target.value });
-    });
+    }, 500));
 
     const addNewSlotBtn = document.getElementById('add-new-slot-btn');
     if (addNewSlotBtn) {

--- a/index.html
+++ b/index.html
@@ -191,6 +191,26 @@
         .btn-secondary:hover { background-color: #cbd5e0; box-shadow: 0 4px 8px rgba(0,0,0,0.1); }
         .btn-danger { background-color: #e53e3e; color: #ffffff; border: 1px solid #e53e3e; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
         .btn-danger:hover { background-color: #c53030; box-shadow: 0 4px 8px rgba(0,0,0,0.15); }
+        .btn-primary-outline {
+            background-color: transparent;
+            border: 2px solid #3b82f6;
+            color: #3b82f6;
+            transition: all 0.2s ease-in-out;
+        }
+        .btn-primary-outline:hover {
+            background-color: #eff6ff;
+            color: #2563eb;
+        }
+        body.dark .btn-primary-outline {
+            background-color: transparent;
+            border-color: #60a5fa;
+            color: #60a5fa;
+        }
+        body.dark .btn-primary-outline:hover {
+            background-color: rgba(59, 130, 246, 0.1);
+            border-color: #93c5fd;
+            color: #93c5fd;
+        }
         .icon-btn { display: inline-flex; align-items: center; justify-content: center; padding: 0.5rem; border-radius: 0.375rem; border: 1px solid transparent; color: #4a5568; }
         .icon-btn:hover { background-color: #e2e8f0; border-color: #cbd5e0; }
         .icon-btn:disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
@@ -201,8 +221,8 @@
         .activity-text-editable:focus, .time-editable:focus { border-bottom: 1px solid #3b82f6; background-color: #f0f8ff; }
         .confirm-action { background-color: #fef2f2 !important; border-color: #ef4444 !important; color: #ef4444 !important; }
         /* --- Day Type Toggle Styles --- */
-        .day-type-toggle { 
-            background-color: #f3f4f6; 
+        .day-type-toggle {
+            background-color: #f3f4f6;
             transition: background-color 0.2s ease-in-out;
         }
         .day-type-toggle .toggle-btn.active { 
@@ -572,7 +592,7 @@ body.dark .stat-card-info p {
                     <p id="no-daily-activities-message" class="text-center text-gray-500 italic mt-6 hidden">No activities recorded for this day.</p>
                     <div id="day-view-bottom-controls">
                         <div class="my-6 text-center">
-                            <button id="add-new-slot-btn" class="px-6 py-3 btn-primary rounded-lg flex items-center justify-center mx-auto shadow-md hover:shadow-lg transition-shadow">
+                            <button id="add-new-slot-btn" class="px-6 py-3 btn-primary-outline rounded-lg flex items-center justify-center mx-auto font-semibold">
                                 <i class="fas fa-plus mr-2"></i> Add Activity Slot
                             </button>
                         </div>


### PR DESCRIPTION
This commit addresses two issues:
1. The 'Add Activity' button has been restyled to have a blue outline, blue text, and a white background, with a hover state, to match the theme of the 'Reset all data' button. A new CSS class, `btn-primary-outline`, was created and applied to the button.
2. The daily note saving functionality has been fixed. The event listener was changed from `change` to a debounced `input` event to ensure that notes are saved as the user types, improving the user experience and preventing data loss.