### PR TITLE
Fix duplicate activity bug in day view

### DIFF
--- a/app.js
+++ b/app.js
@@ -657,8 +657,7 @@ function handleUpdateTime(dayDataCopy, payload) {
     }
 
     if (oldTimeKey !== newTimeKey && dayDataCopy.hasOwnProperty(oldTimeKey)) {
-        Object.defineProperty(dayDataCopy, newTimeKey,
-            Object.getOwnPropertyDescriptor(dayDataCopy, oldTimeKey));
+        dayDataCopy[newTimeKey] = dayDataCopy[oldTimeKey];
         delete dayDataCopy[oldTimeKey];
     }
     return "Time updated!";
@@ -1354,7 +1353,7 @@ function handleInlineEditBlur(event) {
     const target = event.currentTarget;
     if (state.editingInlineTimeKey === target.dataset.time) {
         if (target.classList.contains('time-editable')) {
-            saveData({ type: ACTION_TYPES.UPDATE_TIME, payload: { oldTimeKey: target.dataset.time, newTimeKey: target.innerText.trim() } });
+            saveData({ type: ACTION_TYPES.UPDATE_TIME, payload: { oldTimeKey: state.editingInlineTimeKey, newTimeKey: target.innerText.trim() } });
         } else {
             saveData({ type: ACTION_TYPES.UPDATE_ACTIVITY_TEXT, payload: { timeKey: target.dataset.time, newText: target.innerText.trim() } });
         }


### PR DESCRIPTION
When editing a timeslot in the day view, a duplicate activity was being created instead of updating the existing one. This was caused by a combination of a race condition and incorrect data handling.

This commit fixes the issue by:
- Simplifying the `handleUpdateTime` function to correctly reassign the activity to the new time key and delete the old one.
- Making the `handleInlineEditBlur` function more resilient by using `state.editingInlineTimeKey` to ensure the correct `oldTimeKey` is used, preventing race conditions.

These changes ensure that editing a timeslot correctly updates the activity without creating duplicates.